### PR TITLE
Criar botão com icone de mais

### DIFF
--- a/src/assets/botao-mais-branco.svg
+++ b/src/assets/botao-mais-branco.svg
@@ -1,0 +1,19 @@
+<svg width="47" height="45" viewBox="0 0 47 45" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d)">
+<path d="M41 21.5C41 32.8218 31.8218 42 20.5 42C9.17816 42 0 32.8218 0 21.5C0 10.1782 9.17816 1 20.5 1C31.8218 1 41 10.1782 41 21.5ZM2.32456 21.5C2.32456 31.538 10.462 39.6754 20.5 39.6754C30.538 39.6754 38.6754 31.538 38.6754 21.5C38.6754 11.462 30.538 3.32456 20.5 3.32456C10.462 3.32456 2.32456 11.462 2.32456 21.5Z" fill="white"/>
+</g>
+<rect x="20" y="11" width="2" height="20" rx="1" fill="white"/>
+<path d="M12 22C11.4477 22 11 21.5523 11 21C11 20.4477 11.4477 20 12 20L30 20C30.5523 20 31 20.4477 31 21C31 21.5523 30.5523 22 30 22L12 22Z" fill="white"/>
+<defs>
+<filter id="filter0_d" x="0" y="0" width="47" height="45" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feMorphology radius="4" operator="erode" in="SourceAlpha" result="effect1_dropShadow"/>
+<feOffset dx="4" dy="1"/>
+<feGaussianBlur stdDeviation="3"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.35 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/src/assets/botao-mais-verde.svg
+++ b/src/assets/botao-mais-verde.svg
@@ -1,0 +1,19 @@
+<svg width="53" height="53" viewBox="0 0 53 53" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d)">
+<path d="M43 25.5C43 36.8218 33.8218 46 22.5 46C11.1782 46 2 36.8218 2 25.5C2 14.1782 11.1782 5 22.5 5C33.8218 5 43 14.1782 43 25.5ZM4.32456 25.5C4.32456 35.538 12.462 43.6754 22.5 43.6754C32.538 43.6754 40.6754 35.538 40.6754 25.5C40.6754 15.462 32.538 7.32456 22.5 7.32456C12.462 7.32456 4.32456 15.462 4.32456 25.5Z" fill="#10C732"/>
+</g>
+<rect x="22" y="15" width="2" height="20" rx="1" fill="#10C732"/>
+<path d="M14 26C13.4477 26 13 25.5523 13 25C13 24.4477 13.4477 24 14 24L32 24C32.5523 24 33 24.4477 33 25C33 25.5523 32.5523 26 32 26L14 26Z" fill="#10C732"/>
+<defs>
+<filter id="filter0_d" x="0" y="0" width="53" height="53" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feMorphology radius="2" operator="erode" in="SourceAlpha" result="effect1_dropShadow"/>
+<feOffset dx="4" dy="1"/>
+<feGaussianBlur stdDeviation="4"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/src/components/BotaoMais/index.js
+++ b/src/components/BotaoMais/index.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import {Link} from 'react-router-dom'
+import whiteButton from '../../assets/botao-mais-branco.svg'
+import greenButton from '../../assets/botao-mais-verde.svg'
+
+export function BotaoMais({color="white",to,...props}) {
+
+  const choosedImg = color == "white" ? whiteButton : greenButton 
+  console.log(choosedImg)
+  return (
+    <Link to={to}>
+      <img 
+        {...props}
+        style={{
+            width:42,
+            height:42,
+            objectFit:'cover', 
+            display:'block'
+        }} 
+        src={choosedImg} 
+        alt="Um botão que te leva para a criação do componente onde você esta"
+      />
+    </Link>
+  )
+}


### PR DESCRIPTION
## Contexto
 Criar um componente de botão para utilizar nas telas de listar estufas, listar elementos, listar plantas
 ## Layout 
N/A
 ## Task N/A 
 ## Antes ![image](https://user-images.githubusercontent.com/52542050/131268583-37cbb031-2269-48f6-95a7-2741edff9fe7.png) 
 ## Depois ![image](https://user-images.githubusercontent.com/52542050/131268546-1a25b11d-5954-41c3-ae0a-8ab506508fab.png) 
 - [x] Adicionar uma propriedade to, para dizer para o onde o usuário deve ir ao clicar 
 - [x] Adicionar uma propriedade color (white, green), que deve ser passada para trocar a cor do botão 
 - [x] Repassado os props para a tag img